### PR TITLE
Fix ambiguity error in `randn(2)[namedoneto(2, "i")]`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "NamedDimsArrays"
 uuid = "60cbd0c0-df58-4cb7-918c-6f5607b73fde"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
-version = "0.4.3"
+version = "0.4.4"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/abstractnameddimsarray.jl
+++ b/src/abstractnameddimsarray.jl
@@ -523,6 +523,10 @@ end
 function Base.getindex(a::AbstractArray, I1::NamedViewIndex, Irest::NamedViewIndex...)
   return copy(view(a, I1, Irest...))
 end
+# Disambiguate from `Base.getindex(A::Array, I::AbstractUnitRange{<:Integer})`.
+function Base.getindex(a::Array, I1::AbstractNamedUnitRange{<:Integer})
+  return copy(view(a, I1))
+end
 
 function Base.view(a::AbstractArray, I1::Name, Irest::Name...)
   return nameddimsarray(a, name.((I1, Irest...)))

--- a/test/test_basics.jl
+++ b/test/test_basics.jl
@@ -68,6 +68,8 @@ using Test: @test, @test_throws, @testset
     @test dims(na, ("j", "i")) == (2, 1)
     @test na[1, 1] == a[1, 1]
 
+    a = randn(elt, 3, 4)
+    na = nameddimsarray(a, ("i", "j"))
     for na′ in (
       similar(na, Float32, (j, i)),
       similar(na, Float32, NaiveOrderedSet((j, i))),
@@ -83,6 +85,8 @@ using Test: @test, @test_throws, @testset
       @test na′ ≠ na
     end
 
+    a = randn(elt, 3, 4)
+    na = nameddimsarray(a, ("i", "j"))
     for na′ in (
       similar(na, (j, i)),
       similar(na, NaiveOrderedSet((j, i))),
@@ -114,8 +118,19 @@ using Test: @test, @test_throws, @testset
     @test size(na, i) == si
     @test size(na, j) == sj
 
+    # Regression test for ambiguity error with
+    # `Base.getindex(A::Array, I::AbstractUnitRange{<:Integer})`.
+    i = namedoneto(2, "i")
+    a = randn(elt, 2)
+    na = a[i]
+    @test na isa NamedDimsArray{elt}
+    @test dimnames(na) == ("i",)
+    @test dename(na) == a
+
     # aliasing
-    a′ = randn(2, 2)
+    a′ = randn(elt, 2, 2)
+    i = Name("i")
+    j = Name("j")
     a′ij = @view a′[i, j]
     a′ij[i[1], j[2]] = 12
     @test a′ij[i[1], j[2]] == 12
@@ -126,7 +141,9 @@ using Test: @test, @test_throws, @testset
     @test a′ij[i[2], j[1]] == 21
     @test a′[2, 1] == 21
 
-    a′ = randn(2, 2)
+    a′ = randn(elt, 2, 2)
+    i = Name("i")
+    j = Name("j")
     a′ij = a′[i, j]
     a′ij[i[1], j[2]] = 12
     @test a′ij[i[1], j[2]] == 12
@@ -137,6 +154,8 @@ using Test: @test, @test_throws, @testset
     @test a′ij[i[2], j[1]] ≠ 21
     @test a′[2, 1] ≠ 21
 
+    a = randn(elt, 3, 4)
+    na = nameddimsarray(a, ("i", "j"))
     a′ = dename(na)
     @test a′ isa Matrix{elt}
     @test a′ == a


### PR DESCRIPTION
This fixes https://github.com/ITensor/ITensorBase.jl/issues/25.