### PR TITLE
Don't forward `dename` to `parent` by default, more generic `Array` conversion and `copyto!`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "NamedDimsArrays"
 uuid = "60cbd0c0-df58-4cb7-918c-6f5607b73fde"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
-version = "0.4.5"
+version = "0.5.0"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/nameddimsarray.jl
+++ b/src/nameddimsarray.jl
@@ -31,8 +31,9 @@ function NamedDimsArray(a::AbstractNamedDimsArray)
 end
 
 # Minimal interface.
-nameddimsindices(a::NamedDimsArray) = a.nameddimsindices
-Base.parent(a::NamedDimsArray) = a.parent
+nameddimsindices(a::NamedDimsArray) = getfield(a, :nameddimsindices)
+Base.parent(a::NamedDimsArray) = getfield(a, :parent)
+dename(a::NamedDimsArray) = parent(a)
 
 function TypeParameterAccessors.position(
   ::Type{<:AbstractNamedDimsArray}, ::typeof(parenttype)

--- a/test/test_basics.jl
+++ b/test/test_basics.jl
@@ -73,6 +73,30 @@ using Test: @test, @test_throws, @testset
 
     a = randn(elt, 3, 4)
     na = nameddimsarray(a, ("i", "j"))
+    a′ = Array(na)
+    @test eltype(a′) === elt
+    @test a′ isa Matrix{elt}
+    @test a′ == a
+
+    a = randn(elt, 3, 4)
+    na = nameddimsarray(a, ("i", "j"))
+    for a′ in (Array{Float32}(na), Matrix{Float32}(na))
+      @test eltype(a′) === Float32
+      @test a′ isa Matrix{Float32}
+      @test a′ == Float32.(a)
+    end
+
+    a = randn(elt, 2, 2, 2)
+    na = nameddimsarray(a, ("i", "j", "k"))
+    b = randn(elt, 2, 2, 2)
+    nb = nameddimsarray(b, ("k", "i", "j"))
+    copyto!(na, nb)
+    @test na == nb
+    @test dename(na) == dename(nb, ("i", "j", "k"))
+    @test dename(na) == permutedims(dename(nb), (2, 3, 1))
+
+    a = randn(elt, 3, 4)
+    na = nameddimsarray(a, ("i", "j"))
     i = namedoneto(3, "i")
     j = namedoneto(4, "j")
     ai, aj = axes(na)


### PR DESCRIPTION
This is breaking since [ITensorBase.jl](https://github.com/ITensor/ITensorBase.jl) only defines `parent`, not `dename`, `ITensorBase.ITensor`, but this now requires overloading `dename` explicitly.