### PR TITLE
Compact printing of NamedDimsArray type

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "NamedDimsArrays"
 uuid = "60cbd0c0-df58-4cb7-918c-6f5607b73fde"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
-version = "0.5.1"
+version = "0.5.2"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/abstractnameddimsarray.jl
+++ b/src/abstractnameddimsarray.jl
@@ -969,15 +969,10 @@ function concretetype_to_string_truncated(type::Type; param_truncation_length=ty
   return str
 end
 
-function summary_nameddims(io::IO, a::AbstractArray)
+function Base.summary(io::IO, a::AbstractNamedDimsArray)
   print(io, dims_to_string(nameddimsindices(a)))
   print(io, ' ')
   print(io, concretetype_to_string_truncated(typeof(a); param_truncation_length=40))
-  return nothing
-end
-
-function Base.summary(io::IO, a::AbstractNamedDimsArray)
-  summary_nameddims(io, a)
   return nothing
 end
 

--- a/src/abstractnameddimsarray.jl
+++ b/src/abstractnameddimsarray.jl
@@ -935,6 +935,52 @@ end
 
 # Printing
 
+# Copy of `Base.dims2string` defined in `show.jl`.
+function dims_to_string(d)
+  isempty(d) && return "0-dimensional"
+  length(d) == 1 && return "$(d[1])-element"
+  return join(map(string, d), '×')
+end
+
+using TypeParameterAccessors: type_parameters, unspecify_type_parameters
+function concretetype_to_string_truncated(type::Type; param_truncation_length=typemax(Int))
+  isconcretetype(type) || throw(ArgumentError("Type must be concrete."))
+  alias = Base.make_typealias(type)
+  base_type, params = if isnothing(alias)
+    unspecify_type_parameters(type), type_parameters(type)
+  else
+    base_type_globalref, params_svec = alias
+    base_type_globalref.name, params_svec
+  end
+  str = string(base_type)
+  if isempty(params)
+    return str
+  end
+  str *= '{'
+  param_strings = map(params) do param
+    param_string = string(param)
+    if length(param_string) > param_truncation_length
+      return "…"
+    end
+    return param_string
+  end
+  str *= join(param_strings, ", ")
+  str *= '}'
+  return str
+end
+
+function summary_nameddims(io::IO, a::AbstractArray)
+  print(io, dims_to_string(nameddimsindices(a)))
+  print(io, ' ')
+  print(io, concretetype_to_string_truncated(typeof(a); param_truncation_length=40))
+  return nothing
+end
+
+function Base.summary(io::IO, a::AbstractNamedDimsArray)
+  summary_nameddims(io, a)
+  return nothing
+end
+
 function Base.show(io::IO, mime::MIME"text/plain", a::AbstractNamedDimsArray)
   summary(io, a)
   println(io)
@@ -943,7 +989,8 @@ function Base.show(io::IO, mime::MIME"text/plain", a::AbstractNamedDimsArray)
 end
 
 function Base.show(io::IO, a::AbstractNamedDimsArray)
-  print(io, "nameddimsarray(")
+  show(io, unspecify_type_parameters(typeof(a)))
+  print(io, "(")
   show(io, dename(a))
   print(io, ", ", nameddimsindices(a), ")")
   return nothing

--- a/test/test_basics.jl
+++ b/test/test_basics.jl
@@ -376,7 +376,13 @@ using Test: @test, @test_throws, @testset
     res = sprint(show, "text/plain", a)
     # Could be either one depending on the namespacing.
     @test (res == ref("")) || (res == ref("NamedDimsArrays."))
-    @test sprint(show, a) ==
-      "NamedDimsArray([1 2; 3 4], (named(Base.OneTo(2), \"i\"), named(Base.OneTo(2), \"j\")))"
+
+    a = NamedDimsArray([1 2; 3 4], ("i", "j"))
+    function ref(prefix)
+      return "$(prefix)NamedDimsArray([1 2; 3 4], (named(Base.OneTo(2), \"i\"), named(Base.OneTo(2), \"j\")))"
+    end
+    res = sprint(show, a)
+    # Could be either one depending on the namespacing.
+    @test (res == ref("")) || (res == ref("NamedDimsArrays."))
   end
 end

--- a/test/test_basics.jl
+++ b/test/test_basics.jl
@@ -368,4 +368,9 @@ using Test: @test, @test_throws, @testset
       @test s′[3] == "c"
     end
   end
+  @testset "show" begin
+    a = NamedDimsArray([1 2; 3 4], ("i", "j"))
+    @test sprint(show, "text/plain", a) ==
+      "named(Base.OneTo(2), \"i\")×named(Base.OneTo(2), \"j\") NamedDimsArray{Int64, 2, Matrix{Int64}, …}\n2×2 Matrix{Int64}:\n 1  2\n 3  4"
+  end
 end

--- a/test/test_basics.jl
+++ b/test/test_basics.jl
@@ -370,8 +370,12 @@ using Test: @test, @test_throws, @testset
   end
   @testset "show" begin
     a = NamedDimsArray([1 2; 3 4], ("i", "j"))
-    @test sprint(show, "text/plain", a) ==
-      "named(Base.OneTo(2), \"i\")×named(Base.OneTo(2), \"j\") NamedDimsArray{Int64, 2, Matrix{Int64}, …}\n2×2 Matrix{Int64}:\n 1  2\n 3  4"
+    function ref(prefix)
+      return "named(Base.OneTo(2), \"i\")×named(Base.OneTo(2), \"j\") $(prefix)NamedDimsArray{Int64, 2, Matrix{Int64}, …}\n2×2 Matrix{Int64}:\n 1  2\n 3  4"
+    end
+    res = sprint(show, "text/plain", a)
+    # Could be either one depending on the namespacing.
+    @test (res == ref("")) || (res == ref("NamedDimsArrays."))
     @test sprint(show, a) ==
       "NamedDimsArray([1 2; 3 4], (named(Base.OneTo(2), \"i\"), named(Base.OneTo(2), \"j\")))"
   end

--- a/test/test_basics.jl
+++ b/test/test_basics.jl
@@ -372,5 +372,7 @@ using Test: @test, @test_throws, @testset
     a = NamedDimsArray([1 2; 3 4], ("i", "j"))
     @test sprint(show, "text/plain", a) ==
       "named(Base.OneTo(2), \"i\")×named(Base.OneTo(2), \"j\") NamedDimsArray{Int64, 2, Matrix{Int64}, …}\n2×2 Matrix{Int64}:\n 1  2\n 3  4"
+    @test sprint(show, a) ==
+      "NamedDimsArray([1 2; 3 4], (named(Base.OneTo(2), \"i\"), named(Base.OneTo(2), \"j\")))"
   end
 end


### PR DESCRIPTION
Fixes #46.

With this PR, printing NamedDimsArray now looks like:
```julia
julia> using NamedDimsArrays: NamedDimsArray

julia> a = NamedDimsArray([1 2; 3 4], ("i", "j"))
named(Base.OneTo(2), "i")×named(Base.OneTo(2), "j") NamedDimsArray{Int64, 2, Matrix{Int64}, …}
2×2 Matrix{Int64}:
 1  2
 3  4
```
i.e. printing the named dimensions is more succinct, and also long type parameters are suppressed.