### PR TITLE
CompatHelper: bump compat for TensorAlgebra to 0.9 for package examples, (keep existing compat)

### DIFF
--- a/examples/Project.toml
+++ b/examples/Project.toml
@@ -8,4 +8,4 @@ path = ".."
 
 [compat]
 NamedDimsArrays = "0.15"
-TensorAlgebra = "0.8"
+TensorAlgebra = "0.8, 0.9"


### PR DESCRIPTION
This pull request changes the compat entry for the `TensorAlgebra` package from `0.8` to `0.8, 0.9` for package examples.
This keeps the compat entries for earlier versions.



Note: I have not tested your package with this new compat entry.
It is your responsibility to make sure that your package tests pass before you merge this pull request.