### PR TITLE
Fix nested `LittleSet`; add type-domain methods to `nametype` and `denamedtype` for `NamedDimsArray`.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "NamedDimsArrays"
 uuid = "60cbd0c0-df58-4cb7-918c-6f5607b73fde"
-version = "0.15.2"
+version = "0.15.3"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
 
 [workspace]

--- a/src/littleset.jl
+++ b/src/littleset.jl
@@ -3,6 +3,8 @@ using Base.Broadcast: AbstractArrayStyle, Broadcasted, Style
 struct LittleSet{Values}
     values::Values
 end
+LittleSet(s::LittleSet{V}) where {V} = LittleSet{V}(s)
+LittleSet{V1}(s::LittleSet{V2}) where {V1, V2} = LittleSet{V1}(s.values)
 Base.Tuple(s::LittleSet) = Tuple(s.values)
 Base.eltype(s::LittleSet) = eltype(s.values)
 Base.length(s::LittleSet) = length(s.values)

--- a/src/nameddimsarray.jl
+++ b/src/nameddimsarray.jl
@@ -1,4 +1,5 @@
-using TypeParameterAccessors: TypeParameterAccessors, parenttype
+using TypeParameterAccessors:
+    TypeParameterAccessors, Position, get_type_parameters, parenttype
 
 # TODO: Check `allunique(dimnames)`?
 struct NamedDimsArray{
@@ -34,8 +35,11 @@ dimnames(a::NamedDimsArray) = LittleSet(a.dimnames)
 denamed(a::NamedDimsArray) = a.denamed
 Base.parent(a::NamedDimsArray) = denamed(a)
 
+denamedtype(T::Type{<:NamedDimsArray}) = get_type_parameters(T, Position(3))
+nametype(T::Type{<:NamedDimsArray}) = eltype(get_type_parameters(T, Position(4)))
+
 function TypeParameterAccessors.position(
         ::Type{<:AbstractNamedDimsArray}, ::typeof(parenttype)
     )
-    return TypeParameterAccessors.Position(3)
+    return Position(3)
 end

--- a/test/test_basics.jl
+++ b/test/test_basics.jl
@@ -402,10 +402,11 @@ end
         end
 
         s = LittleSet((1, 2, 3))
+        @test LittleSet(s).values isa Tuple
         @test LittleSet(s) == s
         sp = LittleSet{NTuple{3, Float64}}(s)
         @test eltype(sp) === Float64
-        @test sp.values == (1.0, 2.0, 3.0)
+        @test values(sp) == (1.0, 2.0, 3.0)
     end
     @testset "show" begin
         a = NamedDimsArray([1 2; 3 4], ("i", "j"))

--- a/test/test_basics.jl
+++ b/test/test_basics.jl
@@ -1,9 +1,9 @@
 using Combinatorics: Combinatorics
 using NamedDimsArrays: @names, AbstractNamedDimsArray, AbstractNamedDimsMatrix, LittleSet,
     Name, NameMismatch, NamedDimsArray, NamedDimsCartesianIndex, NamedDimsCartesianIndices,
-    NamedDimsMatrix, aligndims, aligneddims, apply, dename, denamed, dim, dimnames, dims,
-    fusednames, inds, isnamed, mapinds, name, named, nameddims, namedoneto, product,
-    replacedimnames, replaceinds, setinds
+    NamedDimsMatrix, aligndims, aligneddims, apply, dename, denamed, denamedtype, dim,
+    dimnames, dims, fusednames, inds, isnamed, mapinds, name, named, nameddims, namedoneto,
+    nametype, product, replacedimnames, replaceinds, setinds
 using Test: @test, @test_throws, @testset
 using VectorInterface: scalartype
 
@@ -43,6 +43,8 @@ end
         @test dim(na, "j") == 2
         @test dims(na, ("j", "i")) == (2, 1)
         @test na[1, 1] == a[1, 1]
+        @test denamedtype(typeof(na)) === typeof(a)
+        @test nametype(typeof(na)) === String
 
         # equals (==)/isequal
         a = randn(elt, 3, 4)

--- a/test/test_basics.jl
+++ b/test/test_basics.jl
@@ -398,6 +398,12 @@ end
             @test s′[2] == "x"
             @test s′[3] == "c"
         end
+
+        s = LittleSet((1, 2, 3))
+        @test LittleSet(s) == s
+        sp = LittleSet{NTuple{3, Float64}}(s)
+        @test eltype(sp) === Float64
+        @test sp.values == (1.0, 2.0, 3.0)
     end
     @testset "show" begin
         a = NamedDimsArray([1 2; 3 4], ("i", "j"))


### PR DESCRIPTION
These changes are required for the revamp of the `TensorNetwork` (specifically the reverse index mapping). 

Should fix: https://github.com/ITensor/ITensorBase.jl/issues/159