### PR TITLE
Route sum through the underlying data for AbstractNamedDimsArray

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "NamedDimsArrays"
 uuid = "60cbd0c0-df58-4cb7-918c-6f5607b73fde"
-version = "0.15.7"
+version = "0.15.8"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
 
 [workspace]

--- a/src/abstractnameddimsarray.jl
+++ b/src/abstractnameddimsarray.jl
@@ -820,6 +820,14 @@ function Base.mapreduce(f, op, a::AbstractNamedDimsArray; kwargs...)
     return mapreduce(f, op, denamed(a); kwargs...)
 end
 
+# `sum` is routed to the underlying data rather than left to fall back on the
+# `mapreduce` method above because some array types (such as graded arrays) define
+# `Base.sum` directly but not the general `mapreduce`, so the denamed `sum` is the
+# path that works for them.
+function Base.sum(a::AbstractNamedDimsArray; kwargs...)
+    return sum(denamed(a); kwargs...)
+end
+
 function LinearAlgebra.promote_leaf_eltypes(a::AbstractNamedDimsArray)
     return LinearAlgebra.promote_leaf_eltypes(denamed(a))
 end

--- a/test/test_basics.jl
+++ b/test/test_basics.jl
@@ -327,6 +327,16 @@ end
         @test LinearAlgebra.promote_leaf_eltypes(a) ===
             LinearAlgebra.promote_leaf_eltypes(denamed(a))
     end
+    @testset "sum/mapreduce (eltype=$elt)" for elt in TestBasicsUtils.elts
+        # Reductions delegate to the underlying storage. `sum` is routed directly
+        # rather than left to the generic `mapreduce` fallback because some backends
+        # (such as graded arrays) define `Base.sum` without the general `mapreduce`,
+        # so summing the denamed data is the path that works for them.
+        i, j = namedoneto.((2, 3), ("i", "j"))
+        a = randn(elt, i, j)
+        @test sum(a) == sum(denamed(a))
+        @test mapreduce(identity, +, a) == mapreduce(identity, +, denamed(a))
+    end
     @testset "begin/end (eltype=$elt)" for elt in TestBasicsUtils.elts
         i, j = namedoneto.((2, 3), ("i", "j"))
         a = randn(elt, i, j)


### PR DESCRIPTION
## Summary

Adds a `Base.sum` method for `AbstractNamedDimsArray` that reduces the underlying (denamed) data. The generic `sum` falls back on `mapreduce`, but some backends such as graded arrays define `Base.sum` directly without a general `mapreduce`, so that fallback scalar-indexes and fails on them. Reducing the denamed data dispatches to the backend's own `sum`.